### PR TITLE
Make the result-verification-key optional in the discovery document

### DIFF
--- a/cddl/discovery.cddl
+++ b/cddl/discovery.cddl
@@ -7,7 +7,7 @@ coserv-well-known-info = {
   version-label => version,
   capabilities-label => [ + capability ],
   api-endpoints-label => { + tstr => tstr },
-  result-verification-key-label => eat.JC<jwk.JWK_Set, cose.COSE_KeySet>
+  ? result-verification-key-label => eat.JC<jwk.JWK_Set, cose.COSE_KeySet>
 }
 
 version-label = eat.JC<"version", 1>

--- a/cddl/examples/discovery-unsigned.diag
+++ b/cddl/examples/discovery-unsigned.diag
@@ -1,0 +1,14 @@
+{
+  / version / 1: "1.2.3-beta",
+  / capabilities / 2: [
+    {
+      / media-type / 1: "application/coserv+cbor; profile=\"tag:vendor.com,2025:cc_platform#1.0.0\"",
+      / artifact-support / 2: [
+        "collected"
+      ]
+    }
+  ],
+  / api-endpoints / 3: {
+    "CoSERVRequestResponse": "/endorsement-distribution/v1/coserv/{query}"
+  }
+}

--- a/cddl/examples/discovery-unsigned.json
+++ b/cddl/examples/discovery-unsigned.json
@@ -1,0 +1,14 @@
+{
+  "version": "1.2.3-beta",
+  "capabilities": [
+    {
+      "media-type": "application/coserv+cbor; profile=\"tag:vendor.com,2025:cc_platform#1.0.0\"",
+      "artifact-support": [
+        "collected"
+      ]
+    }
+  ],
+  "api-endpoints": {
+    "CoSERVRequestResponse": "/endorsement-distribution/v1/coserv/{query}"
+  }
+}

--- a/draft-ietf-rats-coserv.md
+++ b/draft-ietf-rats-coserv.md
@@ -580,6 +580,14 @@ This field provides one or more public keys that can be used for the cryptograph
 In JSON-formatted discovery documents, each key is a JSON Web Key (JWK) as defined in {{RFC7517}}.
 In CBOR-formatted discovery documents, each key is a COSE Key as defined in {{-cose}}.
 
+This field is optional.
+As described in {{signed-coserv}}, there are situations where it is permissible for CoSERV result sets to be unsigned, namely when they are transacted over an end-to-end secure channel without any untrusted intermediaries.
+CoSERV service implementations MAY publish discovery documents without result-verification keys in cases where they exclusively produce unsigned CoSERV result sets.
+Unsigned CoSERV result sets are characterized by use of the `application/coserv+cbor` media type (as opposed to the `application/coserv+cose` media type).
+The supported media types, along with their profile parameters, are published in the `capabilities` field of the discovery document.
+If all supported media types are variants of `application/coserv+cbor`, indicating unsigned results only, then there is no need for the verification key set to be included in the discovery document.
+If one or more of the supported media types are variants of `application/coserv+cose`, indicating signed results, then the verification key set MUST be included.
+
 #### Discovery Document CBOR Encoding
 
 When the discovery document is encoded as CBOR, it is exempt from the encoding rules specified in {{secencoding}}.


### PR DESCRIPTION
- Adjust the CDDL for the discovery document so that the `result-verification-key` field is optional
- Add CBOR and JSON examples for the case where the key is absent
- Add a paragraph to the draft explaining the optionality and specifying the conditions where the keyset can be omitted.

Signed-off-by: Paul Howard <paul.howard@arm.com>