### PR TITLE
Preparations for next release

### DIFF
--- a/draft-ietf-rats-coserv.md
+++ b/draft-ietf-rats-coserv.md
@@ -1,7 +1,7 @@
 ---
 title: "Concise Selector for Endorsements and Reference Values"
 abbrev: "CoSERV"
-category: info
+category: std
 
 docname: draft-ietf-rats-coserv-latest
 submissiontype: IETF  # also: "independent", "editorial", "IAB", or "IRTF"

--- a/draft-ietf-rats-coserv.md
+++ b/draft-ietf-rats-coserv.md
@@ -50,6 +50,14 @@ author:
   org: Alibaba Cloud
   email: xynnn@linux.alibaba.com
 
+contributor:
+  - ins: C. Wallace
+    name: Carl Wallace
+    org: Red Hound Software, Inc.
+    email: carl@redhoundsoftware.com
+    contribution: >
+      Carl contributed in-depth reviews, resulting in many improvements and clarifications across the document.
+
 normative:
   RFC4648: base64
   RFC7517: jwk


### PR DESCRIPTION
- Correction to the document category - CoSERV is standards track, not informational. The unsuitable category was inherited from the template defaults and never updated.
- Add Carl Wallace as contributor.

Signed-off-by: Paul Howard <paul.howard@arm.com>